### PR TITLE
Use Homebrew's std_cmake_args

### DIFF
--- a/Formula/corrade.rb
+++ b/Formula/corrade.rb
@@ -12,8 +12,7 @@ class Corrade < Formula
     system "mkdir build"
     cd "build" do
       system "cmake",
-        "-DCMAKE_BUILD_TYPE=Release",
-        "-DCMAKE_INSTALL_PREFIX=#{prefix}",
+        *std_cmake_args,
         ".."
       system "cmake", "--build", "."
       system "cmake", "--build", ".", "--target", "install"

--- a/Formula/magnum-bindings.rb
+++ b/Formula/magnum-bindings.rb
@@ -15,8 +15,7 @@ class MagnumBindings < Formula
     system "mkdir build"
     cd "build" do
       system "cmake",
-        "-DCMAKE_BUILD_TYPE=Release",
-        "-DCMAKE_INSTALL_PREFIX=#{prefix}",
+        *std_cmake_args,
         "-DWITH_PYTHON=ON",
         ".."
       system "cmake", "--build", "."

--- a/Formula/magnum-examples.rb
+++ b/Formula/magnum-examples.rb
@@ -25,8 +25,7 @@ class MagnumExamples < Formula
       # https://github.com/Homebrew/homebrew-core/pull/4482 and nothing
       # happened with https://github.com/erincatto/Box2D/issues/431 yet
       system "cmake",
-        "-DCMAKE_BUILD_TYPE=Release",
-        "-DCMAKE_INSTALL_PREFIX=#{prefix}",
+      *std_cmake_args,
         "-DWITH_ANIMATED_GIF_EXAMPLE=ON",
         "-DWITH_ARCBALL_EXAMPLE=ON",
         "-DWITH_AREALIGHTS_EXAMPLE=ON",

--- a/Formula/magnum-extras.rb
+++ b/Formula/magnum-extras.rb
@@ -13,8 +13,7 @@ class MagnumExtras < Formula
     system "mkdir build"
     cd "build" do
       system "cmake",
-        "-DCMAKE_BUILD_TYPE=Release",
-        "-DCMAKE_INSTALL_PREFIX=#{prefix}",
+        *std_cmake_args,
         "-DWITH_PLAYER=ON",
         "-DWITH_UI=ON",
         "-DWITH_UI_GALLERY=ON",

--- a/Formula/magnum-integration.rb
+++ b/Formula/magnum-integration.rb
@@ -24,8 +24,7 @@ class MagnumIntegration < Formula
     system "mkdir build"
     cd "build" do
       system "cmake",
-        "-DCMAKE_BUILD_TYPE=Release",
-        "-DCMAKE_INSTALL_PREFIX=#{prefix}",
+        *std_cmake_args,
         "-DWITH_BULLET=#{(build.with? 'bullet') ? 'ON' : 'OFF'}",
         "-DWITH_DART=#{(build.with? 'dartsim') ? 'ON' : 'OFF'}",
         "-DWITH_EIGEN=#{(build.with? 'eigen') ? 'ON' : 'OFF'}",

--- a/Formula/magnum-plugins.rb
+++ b/Formula/magnum-plugins.rb
@@ -43,8 +43,7 @@ class MagnumPlugins < Formula
     system "mkdir build"
     cd "build" do
       system "cmake",
-        "-DCMAKE_BUILD_TYPE=Release",
-        "-DCMAKE_INSTALL_PREFIX=#{prefix}",
+        *std_cmake_args,
         "-DWITH_ASSIMPIMPORTER=#{(build.with? 'assimp') ? 'ON' : 'OFF'}",
         "-DWITH_BASISIMAGECONVERTER=ON",
         "-DWITH_BASISIMPORTER=ON",

--- a/Formula/magnum.rb
+++ b/Formula/magnum.rb
@@ -15,8 +15,7 @@ class Magnum < Formula
     system "mkdir build"
     cd "build" do
       system "cmake",
-        "-DCMAKE_BUILD_TYPE=Release",
-        "-DCMAKE_INSTALL_PREFIX=#{prefix}",
+        *std_cmake_args,
         "-DMAGNUM_PLUGINS_DIR=#{HOMEBREW_PREFIX}/lib/magnum",
         "-DWITH_AUDIO=ON",
         "-DWITH_GLFWAPPLICATION=ON",


### PR DESCRIPTION
Among several things, this explicitly passes the correct Xcode sysroot to cmake and on to clang.  Without it, can spuriously get failure to find system symbols similar to these issues: https://stackoverflow.com/questions/58628377/catalina-c-using-cmath-headers-yield-error-no-member-named-signbit-in-th

I don't know the rhyme or reason to why it works sometimes (e.g. magnum from this repo worked for me, but magnum-plugins didn't).